### PR TITLE
Use nullptr as default values for pointer types

### DIFF
--- a/src/bin/lua/array.lua
+++ b/src/bin/lua/array.lua
@@ -190,6 +190,7 @@ function classArray:supcode ()
 			output(') ')
 			local def = 0
 			if self.def ~= '' then def = self.def end
+			def = clean_to_function_default(t, def)
 			if t then
 				output('tolua_to'..t,'(tolua_S,3,',def,'));')
 			else

--- a/src/bin/lua/array.lua
+++ b/src/bin/lua/array.lua
@@ -188,9 +188,8 @@ function classArray:supcode ()
 				output('*')
 			end
 			output(') ')
-			local def = 0
+			local def = get_type_default_value(t)
 			if self.def ~= '' then def = self.def end
-			def = clean_to_function_default(t, def)
 			if t then
 				output('tolua_to'..t,'(tolua_S,3,',def,'));')
 			else

--- a/src/bin/lua/basic.lua
+++ b/src/bin/lua/basic.lua
@@ -426,3 +426,15 @@ function get_is_function(t)
 	end
 	return _is_functions[t] or search_base(t, _base_is_functions) or "tolua_isusertype"
 end
+
+function clean_to_function_default(t, def)
+	-- Replace 0 with nullptr for usertypes and strings
+	if def ~= 0 then
+		return def
+	end
+	
+	if not t or t == 'cppstring' or t == 'string' then
+		return 'nullptr'
+	end
+	return def
+end

--- a/src/bin/lua/basic.lua
+++ b/src/bin/lua/basic.lua
@@ -427,14 +427,12 @@ function get_is_function(t)
 	return _is_functions[t] or search_base(t, _base_is_functions) or "tolua_isusertype"
 end
 
-function clean_to_function_default(t, def)
-	-- Replace 0 with nullptr for usertypes and strings
-	if def ~= 0 then
-		return def
-	end
-	
-	if not t or t == 'cppstring' or t == 'string' then
+-- Returns the default value for a value of type t
+-- e.g. number -> 0, string -> nullptr
+function get_type_default_value(t)
+	if (not t) or (t == 'cppstring') or (t == 'string') then
 		return 'nullptr'
 	end
-	return def
+
+	return 0
 end

--- a/src/bin/lua/declaration.lua
+++ b/src/bin/lua/declaration.lua
@@ -296,6 +296,7 @@ function classDeclaration:outchecktype (narg)
 						def = "(void*)&(const "..type..")"..def
 					end
 				end
+				def = clean_to_function_default(t, def)
 				if t then
 					line = concatparam(line,'tolua_to'..t,'(tolua_S,',narg,',',def,'));')
 				else

--- a/src/bin/lua/declaration.lua
+++ b/src/bin/lua/declaration.lua
@@ -289,14 +289,13 @@ function classDeclaration:outchecktype (narg)
 					local full_type = new_mod..' '..new_type
 					line = concatparam(line,'('..full_type..') ')
 				end
-				local def = 0
+				local def = get_type_default_value(t)
 				if self.def ~= '' then
 					def = self.def
 					if (ptr == '' or self.ptr == '&') and not t then
 						def = "(void*)&(const "..type..")"..def
 					end
 				end
-				def = clean_to_function_default(t, def)
 				if t then
 					line = concatparam(line,'tolua_to'..t,'(tolua_S,',narg,',',def,'));')
 				else

--- a/src/bin/lua/function.lua
+++ b/src/bin/lua/function.lua
@@ -141,7 +141,7 @@ function classFunction:supcode (local_constructor)
 			output(' ',self.const,self.parent.type,'*','self = ')
 			output('(',self.const,self.parent.type,'*) ')
 			local to_func = get_to_function(self.parent.type)
-				output(to_func,'(tolua_S,1,0);')
+				output(to_func,'(tolua_S,1,nullptr);')
 			elseif static then
 				_,_,self.mod = strfind(self.mod,'^%s*static%s%s*(.*)')
 			end

--- a/src/bin/lua/package.lua
+++ b/src/bin/lua/package.lua
@@ -136,7 +136,7 @@ function classPackage:preamble ()
 		for i,v in pairs(_collect) do
 			output('\nstatic int '..v..' (lua_State* tolua_S)')
 			output('{')
-			output(' '..i..'* self = ('..i..'*) tolua_tousertype(tolua_S,1,0);')
+			output(' '..i..'* self = ('..i..'*) tolua_tousertype(tolua_S,1,nullptr);')
 			output('	Mtolua_delete(self);')
 			output('	return 0;')
 			output('}')

--- a/src/bin/lua/variable.lua
+++ b/src/bin/lua/variable.lua
@@ -206,7 +206,8 @@ function classVariable:supcode ()
 						output('#endif\n')
 
 						-- assign value
-						local def = 0
+						local t = isbasic(self.type)
+						local def = get_type_default_value(t)
 						if self.def ~= '' then def = self.def end
 						if self.type == 'char*' and self.dim ~= '' then -- is string
 							output(' strncpy((char*)')
@@ -230,7 +231,6 @@ function classVariable:supcode ()
 							else
 								output(name)
 							end
-							local t = isbasic(self.type)
 							if prop_set then
 								output('(')
 							else
@@ -242,7 +242,6 @@ function classVariable:supcode ()
 								output('*')
 							end
 							output(') ')
-							def = clean_to_function_default(t, def)
 							if t then
 								if isenum(self.type) then
 									output('(int) ')

--- a/src/bin/lua/variable.lua
+++ b/src/bin/lua/variable.lua
@@ -131,7 +131,7 @@ function classVariable:supcode ()
 		output(' ',self.parent.type,'*','self = ')
 		output('(',self.parent.type,'*) ')
 		local to_func = get_to_function(self.parent.type)
-			output(to_func,'(tolua_S,1,0);')
+			output(to_func,'(tolua_S,1,nullptr);')
 		elseif static then
 			_,_,self.mod = strfind(self.mod,'^%s*static%s%s*(.*)')
 		end
@@ -188,7 +188,7 @@ function classVariable:supcode ()
 						output(' ',self.parent.type,'*','self = ')
 						output('(',self.parent.type,'*) ')
 						local to_func = get_to_function(self.parent.type)
-							output(to_func,'(tolua_S,1,0);')
+							output(to_func,'(tolua_S,1,nullptr);')
 							-- check self value
 						end
 						-- check types
@@ -242,6 +242,7 @@ function classVariable:supcode ()
 								output('*')
 							end
 							output(') ')
+							def = clean_to_function_default(t, def)
 							if t then
 								if isenum(self.type) then
 									output('(int) ')


### PR DESCRIPTION
Cuberite's bindings now compile cleanly with `-Wzero-as-null-pointer-constant` enabled.